### PR TITLE
Fix ZstdCompressionWriter configuration not to close fp

### DIFF
--- a/scrapy_zstd/postprocessing.py
+++ b/scrapy_zstd/postprocessing.py
@@ -5,7 +5,7 @@ from zstandard import ZstdCompressor
 
 class ZstdPlugin:
     def __init__(self, file: BinaryIO, feed_options: Dict[str, Any]) -> None:
-        self.writer = ZstdCompressor().stream_writer(file)
+        self.writer = ZstdCompressor().stream_writer(file, closefd=False)
 
     def write(self, data: bytes) -> int:
         return self.writer.write(data)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -7,7 +7,6 @@ from scrapy_zstd.postprocessing import ZstdPlugin
 
 def test_compress_zstd() -> None:
     output_file = BytesIO()
-    output_file.close = lambda: None  # type: ignore
 
     plugin = ZstdPlugin(output_file, {})
     plugin.write(b"hello")


### PR DESCRIPTION
The post-processing plugins are not expected to close given file objects.